### PR TITLE
⚡ update default chart to 21.1.0 (Traefik v2.9.7)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 AIGIS UK (Lotus Labs Ltd)
+Copyright (c) 2023 AIGIS UK (Lotus Labs Ltd)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Terraform module to provision [Traefik](https://traefik.io/traefik/) (v2.x) on
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | namespace | Namespace to install traefik chart into (created if non-existent on target cluster) | string | `traefik` | no |
-| traefik_chart_version | Version of Traefik chart to install | string | `20.6.0` | no |
+| traefik_chart_version | Version of Traefik chart to install | string | `21.1.0` | no |
 | timeout_seconds | Helm chart deployment can sometimes take longer than the default 5 minutes. Set a custom timeout (secs) | number | `800` | no |
 | replica_count | Number of replica pods to create | number | `1` | no |
 | values_file | Name of the traefik helm chart values file to use | string | `values.yaml` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -7,7 +7,7 @@ variable "namespace" {
 variable "traefik_chart_version" {
   description = "Version of Traefik chart to install"
   type        = string
-  default     = "20.6.0" # See https://artifacthub.io/packages/helm/traefik/traefik for latest version(s)
+  default     = "21.1.0" # See https://artifacthub.io/packages/helm/traefik/traefik for latest version(s)
 }
 
 # Helm chart deployment can sometimes take longer than the default 5 minutes


### PR DESCRIPTION
🔑 update license
📄 update readme